### PR TITLE
Feat shared folder upload indicator

### DIFF
--- a/app/components/files/file-inner-item.js
+++ b/app/components/files/file-inner-item.js
@@ -67,7 +67,7 @@ export default class FileInnerItem extends SafeComponent {
             fontWeight: vars.font.weight.bold
         };
         const infoStyle = {
-            color: vars.subtleText,
+            color: vars.extraSubtleText,
             fontSize: vars.font.size.smaller,
             fontWeight: vars.font.weight.regular
         };

--- a/app/components/shared/progress-wide.js
+++ b/app/components/shared/progress-wide.js
@@ -60,7 +60,7 @@ export default class Progress extends SafeComponent {
             marginTop: -1,
             marginBottom: -1,
             height: innerHeight,
-            backgroundColor: vars.semiTransparentBg,
+            backgroundColor: vars.bg,
             borderWidth: 0,
             borderColor: 'red',
             width: this.currentWidth

--- a/app/styles/vars.js
+++ b/app/styles/vars.js
@@ -94,6 +94,7 @@ const vars = {
     fabEnabled: '#FF7D00',
     fabDisabled: '#CFCFCF',
     buttonGreen: '#2CCF84',
+    fileUploadProgressColor: 'rgba(50, 206, 195, 0.12)',
     footerMarginX: 24,
     statusBarHeight,
     layoutPaddingTop,

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "path": "0.12.7",
     "pbkdf2": "github:PeerioTechnologies/pbkdf2",
     "peerio-copy": "github:PeerioTechnologies/peerio-copy#icebear",
-    "peerio-icebear": "github:PeerioTechnologies/peerio-icebear#dev",
+    "peerio-icebear": "github:PeerioTechnologies/peerio-icebear#feat-shared-folder-upload-indicator",
     "peerio-translator": "github:PeerioTechnologies/peerio-translator#v1.0.0",
     "process": "0.11.9",
     "prop-types": "15.5.10",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "path": "0.12.7",
     "pbkdf2": "github:PeerioTechnologies/pbkdf2",
     "peerio-copy": "github:PeerioTechnologies/peerio-copy#icebear",
-    "peerio-icebear": "github:PeerioTechnologies/peerio-icebear#feat-shared-folder-upload-indicator",
+    "peerio-icebear": "github:PeerioTechnologies/peerio-icebear#v4.8.1",
     "peerio-translator": "github:PeerioTechnologies/peerio-translator#v1.0.0",
     "process": "0.11.9",
     "prop-types": "15.5.10",


### PR DESCRIPTION
#### Relevant info and issue/PR links 
https://app.clubhouse.io/peerio/story/3004/mobile-shared-folders-new-upload-indicator-for-sharing-a-folder-in-file-list
https://github.com/PeerioTechnologies/peerio-icebear/pull/143

#### Testing instructions  
N/A

### Notes
Uses `const { progress, progressMax } = this.props.folder;`
This won't do anything until new folder props are live, since it uses a conditional operator on these props.

----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
