### PR TITLE
Feat unread message awareness

### DIFF
--- a/app/components/helpers/test-helper.js
+++ b/app/components/helpers/test-helper.js
@@ -12,7 +12,7 @@ let currentScrollPosition = 0;
  * to the test script. Note that it overrides ref and onScroll
  * event handlers
  */
-const scrollHelper = {
+const scrollHelper = !process.env.NO_DEV_BAR ? null : {
     ref: ref => {
         currentScrollPosition = 0;
         currentScrollView = ref;

--- a/app/components/messaging/chat-list.js
+++ b/app/components/messaging/chat-list.js
@@ -126,9 +126,9 @@ export default class ChatList extends SafeComponent {
         }
         if (!chat.id) return null;
         else if (chat.isChannel) {
-            return <View onLayout={onLayout}> <ChannelListItem chat={chat} /> </View>;
+            return <View onLayout={onLayout}><ChannelListItem chat={chat} /></View>;
         }
-        return <View onLayout={onLayout}> <ChatListItem key={chat.id} chat={chat} /> </View>;
+        return <View onLayout={onLayout}><ChatListItem key={chat.id} chat={chat} /></View>;
     };
 
     onEndReached = () => {

--- a/app/components/messaging/unread-message-indicator.js
+++ b/app/components/messaging/unread-message-indicator.js
@@ -1,0 +1,56 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { observer } from 'mobx-react/native';
+import { reaction } from 'mobx';
+import { TouchableOpacity, View, Text, LayoutAnimation } from 'react-native';
+// TODO fix imports after merging Fonts
+// import { TouchableOpacity, View } from 'react-native';
+// import Text from './controls/custom-text';
+import SafeComponent from '../shared/safe-component';
+import icons from '../helpers/icons';
+import { vars } from '../../styles/styles';
+import { tx } from '../utils/translator';
+
+@observer
+export default class UnreadMessageIndicator extends SafeComponent {
+    componentDidMount() {
+        reaction(() => this.props.visible, () => {
+            LayoutAnimation.easeInEaseOut();
+        }, true);
+    }
+
+    renderThrow() {
+        const { visible, action } = this.props;
+        if (!visible) return null;
+        const container = {
+            position: 'absolute',
+            bottom: 0,
+            right: 0,
+            left: 0,
+            height: 36,
+            marginHorizontal: vars.spacing.small.midi2x,
+            borderTopLeftRadius: 10,
+            borderTopRightRadius: 10,
+            backgroundColor: vars.peerioBlue,
+            justifyContent: 'center',
+            alignItems: 'center'
+        };
+        const text = {
+            color: 'white',
+            marginRight: vars.spacing.small.mini2x
+        };
+        return (
+            <TouchableOpacity style={container} onPress={action}>
+                <View style={{ flexDirection: 'row', marginTop: vars.spacing.small.mini2x }}>
+                    <Text semiBold style={text}>{tx('title_unreadMessages')}</Text>
+                    {icons.plainWhite('keyboard-arrow-down', vars.iconSize)}
+                </View>
+            </TouchableOpacity>
+        );
+    }
+}
+
+UnreadMessageIndicator.propTypes = {
+    visible: PropTypes.bool,
+    action: PropTypes.any
+};


### PR DESCRIPTION
#### Relevant info and issue/PR links 
https://app.clubhouse.io/peerio/story/837/mobile-unread-messages-out-of-view-awareness
Unread message indicator will appear only when there is an unread room, room invite, or DM that is out of view. Clicking the indicator will scroll to the bottom most unread chat or room invite. Currently it scrolls just enough so that the item is visible at the bottom of the screen. This scroll amount can be adjusted if we need it to scroll more (so that it shows some read messages below it for example).
Notes:
- Indicator action also works if you have unread DM's which are below pinned chats. (Tested)
- Since the chat list only renders 10 DM's initially, if you have more than 10 unread DM's and click the indicator, it will scroll to the 10th one only, rather than the bottom most one, since it hasn't rendered yet. The indicator will still be visible and clicking it again will scroll to the bottom most item that has been rendered. I don't know if this behaviour will be an issue for users, and I'm not aware of a way to fix it, since we can't scroll to an item that hasn't been rendered yet.

#### Testing instructions  
Scenario - Behavior
No unread chat/invite - indicator is not visible
Have unread chat/invite in view - indicator is not visible
Have unread chat/invite out of view - indicator is visible. clicking on the indicator will scroll to the bottom most unread chat/invite.

----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
