### PR TITLE
feat: invite method in dm placeholder [branch ch6132]

### DIFF
--- a/app/components/messaging/chat.js
+++ b/app/components/messaging/chat.js
@@ -360,6 +360,7 @@ export default class Chat extends SafeComponent {
     get zeroStateChatInvite() {
         const { chat } = this;
         const participant = chat.otherParticipants[0];
+        const { firstName, fullName, addresses } = participant;
         const emojiTada = require('../../assets/emoji/tada.png');
         const container = {
             flex: 1,
@@ -378,17 +379,26 @@ export default class Chat extends SafeComponent {
             color: vars.lighterBlackText,
             textAlign: 'center',
             fontSize: vars.font.size.bigger,
-            lineHeight: 22,
-            marginBottom: vars.spacing.medium.maxi
+            lineHeight: 22
+        };
+        const inviteMethodStyle = {
+            marginTop: vars.spacing.medium.mini2x,
+            fontSize: vars.font.size.smaller,
+            color: vars.textBlack54
         };
         const headingCopy = chat.isNewUserFromInvite ? 'title_newUserDmInviteHeading' : 'title_dmInviteHeading';
+        const invteMethodCopy = chat.isAutoAdded ? 'title_userInAddressBook' : 'title_invitedUserViaEmail';
         return (
             <View style={container}>
                 <Image source={emojiTada} style={emojiStyle} resizeMode="contain" />
                 <Text style={headingStyle}>
-                    {tx(headingCopy, { contactName: participant.fullName })}
+                    {tx(headingCopy, { contactName: fullName })}
                 </Text>
-                <View style={{ alignItems: 'center' }}>
+                {!chat.isReceived &&
+                <Text semibold style={inviteMethodStyle}>
+                    {tx(invteMethodCopy, { firstName, email: addresses[0] })}
+                </Text>}
+                <View style={{ marginTop: vars.spacing.medium.maxi, alignItems: 'center' }}>
                     <AvatarCircle contact={participant} medium />
                 </View>
                 <Text style={{ textAlign: 'center', marginBottom: vars.spacing.medium.maxi2x }}>

--- a/app/components/messaging/chat.js
+++ b/app/components/messaging/chat.js
@@ -387,7 +387,7 @@ export default class Chat extends SafeComponent {
             color: vars.textBlack54
         };
         const headingCopy = chat.isNewUserFromInvite ? 'title_newUserDmInviteHeading' : 'title_dmInviteHeading';
-        const invteMethodCopy = chat.isAutoAdded ? 'title_userInAddressBook' : 'title_invitedUserViaEmail';
+        const inviteMethodCopy = chat.isAutoImport ? 'title_userInAddressBook' : 'title_invitedUserViaEmail';
         return (
             <View style={container}>
                 <Image source={emojiTada} style={emojiStyle} resizeMode="contain" />
@@ -396,7 +396,7 @@ export default class Chat extends SafeComponent {
                 </Text>
                 {!chat.isReceived &&
                 <Text semibold style={inviteMethodStyle}>
-                    {tx(invteMethodCopy, { firstName, email: addresses[0] })}
+                    {tx(inviteMethodCopy, { firstName, email: addresses[0] })}
                 </Text>}
                 <View style={{ marginTop: vars.spacing.medium.maxi, alignItems: 'center' }}>
                     <AvatarCircle contact={participant} medium />

--- a/app/components/messaging/dm-contact-invite.js
+++ b/app/components/messaging/dm-contact-invite.js
@@ -34,8 +34,13 @@ const headingStyle = {
     color: vars.lighterBlackText,
     textAlign: 'center',
     fontSize: vars.font.size.bigger,
-    lineHeight: 22,
-    marginBottom: vars.spacing.medium.maxi
+    lineHeight: 22
+};
+
+const inviteMethodStyle = {
+    marginTop: vars.spacing.medium.mini2x,
+    fontSize: vars.font.size.smaller,
+    color: vars.textBlack54
 };
 
 const buttonContainer = {
@@ -65,18 +70,24 @@ export default class DmContactInvite extends SafeComponent {
     renderThrow() {
         const { chat } = this;
         const inviter = chat.otherParticipants[0];
+        const { firstName, fullName, usernameTag, addresses } = inviter;
         const headingCopy = chat.isReceived ? 'title_newUserDmInviteHeading' : 'title_dmInviteHeading';
+        const invteMethodCopy = chat.isAutoAdded ? 'title_userInAddressBook' : 'title_invitedUserViaEmail';
         return (
             <View style={container}>
                 <Image source={emojiTada} style={emojiStyle} resizeMode="contain" />
                 <Text style={headingStyle}>
-                    {tx(headingCopy, { contactName: inviter.fullName })}
+                    {tx(headingCopy, { contactName: fullName })}
                 </Text>
-                <View style={{ alignItems: 'center' }}>
+                {!chat.isReceived &&
+                <Text semibold style={inviteMethodStyle}>
+                    {tx(invteMethodCopy, { firstName, email: addresses[0] })}
+                </Text>}
+                <View style={{ marginTop: vars.spacing.medium.maxi, alignItems: 'center' }}>
                     <AvatarCircle contact={inviter} medium />
                 </View>
                 <Text style={{ textAlign: 'center', marginBottom: vars.spacing.medium.maxi2x }}>
-                    {inviter.usernameTag}
+                    {usernameTag}
                 </Text>
                 <IdentityVerificationNotice />
                 <View style={buttonContainer}>

--- a/app/components/messaging/dm-contact-invite.js
+++ b/app/components/messaging/dm-contact-invite.js
@@ -72,7 +72,7 @@ export default class DmContactInvite extends SafeComponent {
         const inviter = chat.otherParticipants[0];
         const { firstName, fullName, usernameTag, addresses } = inviter;
         const headingCopy = chat.isReceived ? 'title_newUserDmInviteHeading' : 'title_dmInviteHeading';
-        const invteMethodCopy = chat.isAutoAdded ? 'title_userInAddressBook' : 'title_invitedUserViaEmail';
+        const invteMethodCopy = chat.isAutoImport ? 'title_userInAddressBook' : 'title_invitedUserViaEmail';
         return (
             <View style={container}>
                 <Image source={emojiTada} style={emojiStyle} resizeMode="contain" />

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "path": "0.12.7",
     "pbkdf2": "github:PeerioTechnologies/pbkdf2",
     "peerio-copy": "github:PeerioTechnologies/peerio-copy#icebear",
-    "peerio-icebear": "github:PeerioTechnologies/peerio-icebear#chore-copy-invite-method",
+    "peerio-icebear": "github:PeerioTechnologies/peerio-icebear#feat-show-invite-method-in-chat",
     "peerio-translator": "github:PeerioTechnologies/peerio-translator#v1.0.0",
     "process": "0.11.9",
     "prop-types": "15.5.10",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "path": "0.12.7",
     "pbkdf2": "github:PeerioTechnologies/pbkdf2",
     "peerio-copy": "github:PeerioTechnologies/peerio-copy#icebear",
-    "peerio-icebear": "github:PeerioTechnologies/peerio-icebear#dev",
+    "peerio-icebear": "github:PeerioTechnologies/peerio-icebear#chore-copy-invite-method",
     "peerio-translator": "github:PeerioTechnologies/peerio-translator#v1.0.0",
     "process": "0.11.9",
     "prop-types": "15.5.10",


### PR DESCRIPTION
#### Relevant info and issue/PR links 
https://app.clubhouse.io/peerio/story/6132/mobile-show-method-of-invite-in-dm-placeholder
https://github.com/PeerioTechnologies/peerio-icebear/pull/222
#### Testing instructions  
SDK support is not implemented yet, i mocked the property to differentiate between email invite and contact sync. For now, it just always assumes email invite.
3 cases:
As the inviter: Invite a person to join Peerio using contact add, copy should reflect this
As the inviter: Invite a person to join Peerio using contact sync, copy should reflect this
As the invitee: Be invited by a someone (regardless of method), create an account using the invited email. You shouldn't see the copy, since it should show for the inviter only.

----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
