### PR TITLE
fix: hide deleted recent files [branch ch4353]

### DIFF
--- a/app/components/files/recent-file-item.js
+++ b/app/components/files/recent-file-item.js
@@ -22,6 +22,7 @@ const fileInfoContainerStyle = {
 export default class RecentFileItem extends SafeComponent {
     renderThrow() {
         const { file } = this.props;
+        if (file.deleted) return null;
         const iconRight = icons.dark('more-vert', this.props.onMenu);
         const nameStyle = {
             color: vars.txtDark,


### PR DESCRIPTION
#### Relevant info and issue/PR links 
https://app.clubhouse.io/peerio/story/4353/mobile-reflect-deleted-files-in-recent-files-list-in-chat-info-panel
#### Testing instructions  
Send a file in a DM or Room. Go to the chat info (arrow icon at the top). Find the file in recent files list and click on the file action button. Delete the file. The file should no longer be in the list, and the file in that chat should be replaced with "file unshared".

----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
