### PR TITLE
fix: hide invited contact selector [branch ch9506]

### DIFF
--- a/app/components/channels/create-channel.js
+++ b/app/components/channels/create-channel.js
@@ -132,7 +132,8 @@ export default class CreateChannel extends Component {
                     action={this.createChannel}
                     ref={this.refContactSelector}
                     leftIconComponent={<Text style={titleStyle}>{tx('title_with')}</Text>}
-                    inputPlaceholder="title_roomParticipants" />
+                    inputPlaceholder="title_roomParticipants"
+                    hideInvites />
             </View>
         ) : <View style={card} />;
     }

--- a/app/components/contacts/contact-selector-universal.js
+++ b/app/components/contacts/contact-selector-universal.js
@@ -157,7 +157,7 @@ export default class ContactSelectorUniversal extends SafeComponent {
         if (this.foundContact) {
             result.unshift({ data: [this.foundContact], key: null });
         }
-        if (!this.findUserText) {
+        if (!this.findUserText && !this.props.hideInvites) {
             result.push({ data: contactState.store.invitedContacts.slice(), key: 'title_allYourInvited' });
         }
         return result;
@@ -252,5 +252,6 @@ ContactSelectorUniversal.propTypes = {
     onExit: PropTypes.func,
     multiselect: PropTypes.any,
     footer: PropTypes.any,
-    hideHeader: PropTypes.any
+    hideHeader: PropTypes.any,
+    hideInvites: PropTypes.bool
 };

--- a/app/components/files/file-share.js
+++ b/app/components/files/file-share.js
@@ -13,7 +13,8 @@ export default class FileShare extends Component {
                 action={this.action}
                 title="title_shareWith"
                 inputPlaceholder="title_TryUsernameOrEmail"
-                limit={chatState.LIMIT_PEOPLE_DM} />
+                limit={chatState.LIMIT_PEOPLE_DM}
+                hideInvites />
         );
     }
 }

--- a/app/components/files/folder-share.js
+++ b/app/components/files/folder-share.js
@@ -53,6 +53,7 @@ export default class FolderShare extends Component {
                 inputPlaceholder="title_searchByUsernameOrEmail"
                 multiselect
                 footer={footer}
+                hideInvites
             />);
     }
 

--- a/app/components/messaging/channel-add-people.js
+++ b/app/components/messaging/channel-add-people.js
@@ -33,7 +33,8 @@ export default class ChannelAddPeople extends SafeComponent {
                     exclude={this.excluded}
                     onExit={() => chatState.routerModal.discard()}
                     action={this.addPeople} title={tx('title_addPeopleToRoom')}
-                    inputPlaceholder={tx('title_TryUsernameOrEmail')} />
+                    inputPlaceholder={tx('title_TryUsernameOrEmail')}
+                    hideInvites />
             </View>
         );
     }

--- a/app/components/messaging/compose-message.js
+++ b/app/components/messaging/compose-message.js
@@ -30,7 +30,8 @@ export default class ComposeMessage extends Component {
                 action={contacts => chatState.startChat(contacts)}
                 inputPlaceholder="title_TryUsernameOrEmail"
                 title="title_newDirectMessage"
-                limit={chatState.LIMIT_PEOPLE_DM} />
+                limit={chatState.LIMIT_PEOPLE_DM}
+                hideInvites />
         );
     }
 }


### PR DESCRIPTION
#### Relevant info and issue/PR links 
https://app.clubhouse.io/peerio/story/9506/mobile-new-dm-creation-screen-shows-invited-emails
#### Testing instructions  
Check that you can't find any invited contacts in any of these contact selection screens:
1- Create DM
2- Create Room
3- Add people to Room
4- Share file
5- Share folder

----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
