### PR TITLE
Fix refactor validation state

### DIFF
--- a/app/components/shared/styled-text-input.js
+++ b/app/components/shared/styled-text-input.js
@@ -49,6 +49,7 @@ export default class StyledTextInput extends SafeComponent {
         if (uiState.focusedTextBox === this.textInput) {
             uiState.focusedTextBox = null;
         }
+        this.reaction && this.reaction();
         this.reaction = null;
     }
 

--- a/app/components/shared/styled-text-input.js
+++ b/app/components/shared/styled-text-input.js
@@ -49,6 +49,7 @@ export default class StyledTextInput extends SafeComponent {
         if (uiState.focusedTextBox === this.textInput) {
             uiState.focusedTextBox = null;
         }
+        this.reaction = null;
     }
 
     get isValid() { return this.valid; }

--- a/app/components/shared/styled-text-input.js
+++ b/app/components/shared/styled-text-input.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { observer } from 'mobx-react/native';
-import { observable, action } from 'mobx';
+import { observable, action, reaction } from 'mobx';
 import { TextInput, View, Platform, Animated } from 'react-native';
 import Text from '../controls/custom-text';
 import SafeComponent from '../shared/safe-component';
@@ -10,6 +10,7 @@ import { vars, styledTextInput } from '../../styles/styles';
 import icons from '../helpers/icons';
 import testLabel from '../helpers/test-label';
 import { tx } from '../utils/translator';
+import { socket } from '../../lib/icebear';
 
 // Because JS has no enums
 const VALID = true;
@@ -27,6 +28,7 @@ export default class StyledTextInput extends SafeComponent {
     @observable end = 0;
     @observable focusedAnim;
     @observable errorMessageText;
+    @observable isDirty = false;
 
     constructor(props) {
         super(props);
@@ -34,6 +36,13 @@ export default class StyledTextInput extends SafeComponent {
             this.validate();
         } else this.valid = UNDEFINED;
         this.focusedAnim = new Animated.Value(0);
+    }
+
+    componentDidMount() {
+        this.reaction = reaction(() => socket.connected, () => {
+            // Only run validation on reconnect, not on disconnect
+            if (socket.connected) this.validate();
+        }, true);
     }
 
     componentWillUnmount() {
@@ -63,7 +72,7 @@ export default class StyledTextInput extends SafeComponent {
                     this.errorMessageText = validations[0].message;
                     throw new Error();
                 }
-                if (required) {
+                if (required && this.isDirty) {
                     this.valid = INVALID;
                     this.errorMessageText = tx('title_required');
                 }
@@ -82,6 +91,9 @@ export default class StyledTextInput extends SafeComponent {
      */
     @action.bound async validate() {
         const { validations, alwaysDirty, state } = this.props;
+        // Do not run validation on a field that hasn't been modified yet unless it is alwaysDirty
+        if (!this.isDirty && !alwaysDirty) return;
+        console.log('Running validation');
         this.handleEmptyField();
         // If no validation prop is passed, then no validation is needed and it is always valid
         if (!validations) {
@@ -124,6 +136,7 @@ export default class StyledTextInput extends SafeComponent {
     }
 
     @action.bound async onChangeText(text) {
+        this.isDirty = true;
         // even if not focused, move the hint to the top
         if (text) this.setHintToTop();
         let inputText = text;


### PR DESCRIPTION
#### Relevant info and issue/PR links 
https://app.clubhouse.io/peerio/story/8165/mobile-wrong-validation-state-after-disconnect
#### Testing instructions  
Disconnect device during "sign up user info" step. Any text inputs which have not been validated should not give any errors. On reconnect, the inputs are re-validated, and any invalid inputs would show errors.

Note: During implementation I also tested the case where a text input has the "alwaysDirty" prop, which currently none of our inputs have.

----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
