### PR TITLE
fix: monospace font for android

### DIFF
--- a/app/components/controls/custom-text.js
+++ b/app/components/controls/custom-text.js
@@ -13,11 +13,10 @@ import { vars } from '../../styles/styles';
 @observer
 export default class Text extends SafeComponent {
     renderThrow() {
-        const { semibold, bold, italic, serif, courier } = this.props;
+        const { semibold, bold, italic, serif, monospace } = this.props;
         const style = {};
         let font = [vars.peerioFontFamily];
         if (serif) font = [vars.peerioSerifFontFamily];
-        if (courier) font = [vars.peerioCourierFontFamily];
 
         // Font Weight and Style
         if (Platform.OS === 'android') {
@@ -34,6 +33,7 @@ export default class Text extends SafeComponent {
         }
         style.fontFamily = font.join('');
         if (Platform.OS === 'android') style.fontFamily = style.fontFamily.replace(' ', '');
+        if (monospace) style.fontFamily = vars.peerioCourierFontFamily;
 
         return (
             <RNText {...this.props} style={[this.props.style, style]}>
@@ -63,6 +63,6 @@ Text.propTypes = {
     bold: PropTypes.any,
     italic: PropTypes.any,
     serif: PropTypes.any,
-    courier: PropTypes.any,
+    monospace: PropTypes.any,
     children: PropTypes.any
 };

--- a/app/components/controls/custom-text.js
+++ b/app/components/controls/custom-text.js
@@ -13,10 +13,9 @@ import { vars } from '../../styles/styles';
 @observer
 export default class Text extends SafeComponent {
     renderThrow() {
-        const { semibold, bold, italic, serif, monospace } = this.props;
+        const { semibold, bold, italic, monospace, serif } = this.props;
         const style = {};
-        let font = [vars.peerioFontFamily];
-        if (serif) font = [vars.peerioSerifFontFamily];
+        const font = [serif ? vars.peerioSerifFontFamily : vars.peerioFontFamily];
 
         // Font Weight and Style
         if (Platform.OS === 'android') {
@@ -33,7 +32,11 @@ export default class Text extends SafeComponent {
         }
         style.fontFamily = font.join('');
         if (Platform.OS === 'android') style.fontFamily = style.fontFamily.replace(' ', '');
-        if (monospace) style.fontFamily = vars.peerioCourierFontFamily;
+
+        // Override font
+        if (monospace) {
+            style.fontFamily = Platform.OS === 'android' ? 'monospace' : 'Courier';
+        }
 
         return (
             <RNText {...this.props} style={[this.props.style, style]}>
@@ -62,7 +65,5 @@ Text.propTypes = {
     semibold: PropTypes.any,
     bold: PropTypes.any,
     italic: PropTypes.any,
-    serif: PropTypes.any,
-    monospace: PropTypes.any,
     children: PropTypes.any
 };

--- a/app/components/signup/signup-generation-box.js
+++ b/app/components/signup/signup-generation-box.js
@@ -73,7 +73,7 @@ export default class SignupGenerationBox extends SafeComponent {
                 numberofLines={1}
                 minimumFontScale={0.1}
                 adjustsFontSizeToFit
-                courier
+                monospace
                 bold
                 style={accountKeyStyle}>
                 {signupState.passphrase}

--- a/app/components/signup/signup-pdf-preview.js
+++ b/app/components/signup/signup-pdf-preview.js
@@ -81,7 +81,7 @@ export default class SignupPdfPreview extends SafeComponent {
                             {tx('title_demoPdfUsernameLabel')}
                         </Text>
                         <View style={textBox}>
-                            <Text style={textBoxText} courier>
+                            <Text style={textBoxText} monospace>
                                 {signupState.username}
                             </Text>
                         </View>
@@ -89,7 +89,7 @@ export default class SignupPdfPreview extends SafeComponent {
                             {tx('title_demoPdfAkLabel')}
                         </Text>
                         <View style={textBox}>
-                            <Text style={textBoxText} courier>
+                            <Text style={textBoxText} monospace>
                                 {signupState.passphrase}
                             </Text>
                         </View>


### PR DESCRIPTION
#### Relevant info and issue/PR links 
https://app.clubhouse.io/peerio/story/12202/mobile-sign-up-ui-update
#### Testing instructions  
Check that font works on Android and doesnt crash ios

----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
