### PR TITLE
fix: remove transactionInsert argument mutations

### DIFF
--- a/app/store/sqlcipher-db-storage.js
+++ b/app/store/sqlcipher-db-storage.js
@@ -5,16 +5,47 @@ import CacheEngineBase from '../lib/peerio-icebear/db/cache-engine-base';
 sqlcipher.enablePromise(false);
 
 function serialize(item) {
+    if (
+        !item ||
+        typeof item !== "object" ||
+        Array.isArray(item) ||
+        typeof item === "number" ||
+        typeof item === Date
+    ) {
+        return JSON.stringify(item);
+    }
+
+    let copy;
+    function ensureCopy() {
+        if (copy === undefined) {
+            copy = {
+                ...item
+            };
+        }
+    }
+
     if (item.payload) {
-        item.payload = bytesToB64(item.payload);
+        ensureCopy();
+        copy.payload = bytesToB64(item.payload);
     }
     if (item.chatHead && item.chatHead.payload) {
-        item.chatHead.payload = bytesToB64(item.chatHead.payload);
+        ensureCopy();
+        copy.chatHead = {
+            ...item.chatHead,
+            payload: bytesToB64(item.chatHead.payload)
+        };
     }
     if (item.props && item.props.descriptor && item.props.descriptor.payload) {
-        item.props.descriptor.payload = bytesToB64(item.props.descriptor.payload);
+        ensureCopy();
+        copy.props = {
+            ...item.props,
+            descriptor: {
+                ...item.props.descriptor,
+                payload: bytesToB64(item.props.descriptor.payload)
+            }
+        };
     }
-    return JSON.stringify(item);
+    return JSON.stringify(copy || item);
 }
 
 function deserialize(data) {

--- a/app/store/sqlcipher-db-storage.js
+++ b/app/store/sqlcipher-db-storage.js
@@ -1,7 +1,6 @@
 import sqlcipher from 'react-native-sqlcipher-storage';
 import { b64ToBytes, bytesToB64 } from '../lib/peerio-icebear/crypto/util';
 import CacheEngineBase from '../lib/peerio-icebear/db/cache-engine-base';
-import _ from 'lodash';
 
 sqlcipher.enablePromise(false);
 
@@ -9,23 +8,21 @@ function isBytes(value) {
     return value && (value instanceof Uint8Array || value instanceof ArrayBuffer)
 }
 
-function payloadToBase64(value, key) {
-    if (key === 'payload' && isBytes(value)) return bytesToB64(value);
+function payloadToBase64(key, value) {
+    return (key === 'payload' && isBytes(value)) ? bytesToB64(value) : value
 }
 
-function payloadFromBase64(value, key) {
-    if (key === 'payload' && typeof value === "string") return b64ToBytes(value);
+function payloadFromBase64(key, value) {
+    return (key === 'payload' && typeof value === "string") ? b64ToBytes(value) : value
 }
 
 function serialize(item) {
-    const normalizedData = _.cloneDeepWith(item, payloadToBase64);
-    return JSON.stringify(normalizedData);
+    return JSON.stringify(item, payloadToBase64);
 }
 
 function deserialize(data) {
     try {
-        const item = JSON.parse(data);
-        return _.cloneDeepWith(item, payloadFromBase64);
+        return JSON.parse(data, payloadFromBase64);
     } catch (e) {
         return null;
     }


### PR DESCRIPTION
#### Relevant info and issue/PR links 
IO functions shouldn't mutate given arguments. 
potential issue case: using writeItem second time with same argument.

```
const storage = new SqlCipherDbStorage()
const payload = generatePayload();

const item = {payload}
storage.setValue("key1", item)
.catch(anyError => {
    // I may want to retry this, but item is corrupted because of mutations in serialize function.
    const isPayloadSame = item.payload === payload
    console.log(isPayloadSame)
    // => false
})
```
#### Testing instructions  


----
### Repository owner

- [1] Was tested and can be merged.
- [1] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
