### PR TITLE
fix: wait for authenticated before prompting upload

### DIFF
--- a/app/components/utils/shared-files.js
+++ b/app/components/utils/shared-files.js
@@ -20,7 +20,8 @@ const upload = async (path, fileName, extension) => {
 };
 
 const uploadFileiOS = async (event) => {
-    if (event && event.url && socket.authenticated) {
+    await promiseWhen(() => socket.authenticated);
+    if (event && event.url) {
         const url = decodeURIComponent(event.url);
         const json = url.split('://')[1]; // url format: {urlScheme}://{data}
         const { files, path } = JSON.parse(json);
@@ -48,6 +49,7 @@ const getStoragePermission = async () => {
 
 const uploadFileAndroid = async (sharedFile) => {
     if (sharedFile) {
+        await promiseWhen(() => socket.authenticated);
         const readPermission = await getStoragePermission();
         if (readPermission) {
             // RNFS stat now provides extra things:


### PR DESCRIPTION
#### Relevant info and issue/PR links 
https://app.clubhouse.io/peerio/story/12978/ios-unable-to-upload-to-peerio-on-first-try
#### Testing instructions  
1. put the app to background
wait 60-120 seconds
share file to peerio
2. close Peerio (no backgrounding)
share a file

----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
