### PR TITLE
Refactor chat list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="3.389.0"></a>
+# [3.389.0](https://github.com/PeerioTechnologies/peerio-mobile/compare/v3.385.0...v3.389.0) (2018-10-31)
+
+
+### Bug Fixes
+
+* wait for authenticated before prompting upload ([#357](https://github.com/PeerioTechnologies/peerio-mobile/issues/357)) ([1faedc4](https://github.com/PeerioTechnologies/peerio-mobile/commit/1faedc4))
+
+
+### Features
+
+* chat beacons ([#345](https://github.com/PeerioTechnologies/peerio-mobile/issues/345)) ([941f1db](https://github.com/PeerioTechnologies/peerio-mobile/commit/941f1db))
+
+
+
 <a name="3.388.0"></a>
 # [3.388.0](https://github.com/PeerioTechnologies/peerio-mobile/compare/v3.385.0...v3.388.0) (2018-10-25)
 

--- a/app/components/messaging/chat-list-item.js
+++ b/app/components/messaging/chat-list-item.js
@@ -6,7 +6,7 @@ import { View, TouchableOpacity } from 'react-native';
 import Text from '../controls/custom-text';
 import SafeComponent from '../shared/safe-component';
 import chatState from './chat-state';
-import { User, contactStore } from '../../lib/icebear';
+import { User } from '../../lib/icebear';
 import { tx } from '../utils/translator';
 import { vars } from '../../styles/styles';
 import icons from '../helpers/icons';
@@ -14,6 +14,7 @@ import DmTitle from '../shared/dm-title';
 import AvatarCircle from '../shared/avatar-circle';
 import DeletedCircle from '../shared/deleted-circle';
 import ListSeparator from '../shared/list-separator';
+import contactState from '../contacts/contact-state';
 
 const pinOn = require('../../assets/chat/icon-pin.png');
 
@@ -109,7 +110,7 @@ export default class ChatListItem extends SafeComponent {
         const { otherParticipants, headLoaded } = chat;
         if (chat.isChannel && !headLoaded) return null;
         // no participants means chat with yourself
-        let contact = contactStore.getContact(User.current.username);
+        let contact = contactState.store.getContact(User.current.username);
         // two participants
         if (otherParticipants && otherParticipants.length === 1) {
             contact = otherParticipants[0];

--- a/app/components/messaging/chat-list-item.js
+++ b/app/components/messaging/chat-list-item.js
@@ -104,11 +104,14 @@ export default class ChatListItem extends SafeComponent {
     }
 
     renderThrow() {
-        if (chatState.collapseDMs) return null;
-        if (!this.props || !this.props.chat) return null;
+        if (!this.props || !this.props.chat) {
+            console.error('Null chat provided to chat list item');
+        }
         const { chat } = this.props;
         const { otherParticipants, headLoaded } = chat;
-        if (chat.isChannel && !headLoaded) return null;
+        if (chat.isChannel && !headLoaded) {
+            console.error('Head is not loaded in the provided chat list item. Still rendering');
+        }
         // no participants means chat with yourself
         let contact = contactState.store.getContact(User.current.username);
         // two participants

--- a/app/components/messaging/chat-list-item.js
+++ b/app/components/messaging/chat-list-item.js
@@ -121,12 +121,18 @@ export default class ChatListItem extends SafeComponent {
 
         const key = chat.id;
         const unread = chat.unreadCount > 0;
+        // NOTE: fixed height is used for correct calculation of scrolling
+        // in the parent SectionList. To prevent weird bugs with scrolling,
+        // we force-fix the height here, so that if somebody forgets to update
+        // the item height in section list, it would be visible
+        // (-1) takes into account the separator
+        const height = this.props.height ? this.props.height - 1 : undefined;
         return (
             <TouchableOpacity
                 key={key}
                 onPress={this.onPress}
                 pressRetentionOffset={vars.pressRetentionOffset}>
-                <View style={containerStyle}>
+                <View style={[containerStyle, { height }]}>
                     <View>
                         <View style={pinStyle}>
                             {chat.isFavorite && icons.iconPinnedChat(pinOn)}

--- a/app/components/messaging/chat-list.js
+++ b/app/components/messaging/chat-list.js
@@ -183,11 +183,10 @@ export default class ChatList extends SafeComponent {
      * Scrolls to the topmost unread item in the list
      */
     @action.bound scrollUpToUnread() {
-        const pos = this.firstUnreadItemPosition;
+        const pos = this.firstUnreadItem;
         if (!pos) return;
-        this.scrollView.scrollToLocation({
-            itemIndex: pos.index,
-            sectionIndex: pos.section,
+        this.scrollView.scrollToIndex({
+            index: pos.index,
             viewOffset: drawerState.getDrawer() ? -vars.topDrawerHeight : 0,
             viewPosition: 0
         });
@@ -197,13 +196,12 @@ export default class ChatList extends SafeComponent {
      * Scrolls to the bottommost unread item in the list
      */
     @action.bound scrollDownToUnread() {
-        const pos = this.lastUnreadItemPosition;
+        const pos = this.lastUnreadItem;
         if (!pos) return;
-        this.scrollView.scrollToLocation({
-            itemIndex: pos.index,
-            sectionIndex: pos.section,
+        this.scrollView.scrollToIndex({
+            index: pos.index,
             viewOffset: drawerState.getDrawer() ? -vars.topDrawerHeight : 0,
-            viewPosition: 0.9
+            viewPosition: 1
         });
     }
 

--- a/app/components/messaging/chat-list.js
+++ b/app/components/messaging/chat-list.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { observer } from 'mobx-react/native';
 import { View, Platform } from 'react-native';
 import { observable, reaction, action, computed } from 'mobx';
-import { chatInviteStore, chatStore } from '../../lib/icebear';
+import { chatInviteStore } from '../../lib/icebear';
 import SafeComponent from '../shared/safe-component';
 import ChatListItem from './chat-list-item';
 import ChannelListItem from './channel-list-item';
@@ -55,7 +55,7 @@ export default class ChatList extends SafeComponent {
     }
 
     @computed get firstSectionItems() {
-        const allChannels = chatStore.allRooms || [];
+        const allChannels = chatState.store.allRooms || [];
         allChannels.sort((a, b) => {
             const first = (a.name || a.channelName || '').toLocaleLowerCase();
             const second = (b.name || b.channelName || '').toLocaleLowerCase();
@@ -280,7 +280,7 @@ export default class ChatList extends SafeComponent {
     }
 
     renderThrow() {
-        const body = ((chatStore.chats.length || chatInviteStore.received.length) && chatState.store.loaded) ?
+        const body = ((chatState.store.chats.length || chatInviteStore.received.length) && chatState.store.loaded) ?
             this.listView() : this.zeroStatePlaceholder();
 
         return (

--- a/app/components/messaging/chat-list.js
+++ b/app/components/messaging/chat-list.js
@@ -122,7 +122,7 @@ export default class ChatList extends SafeComponent {
 
     inviteItem = (chat) => <ChannelInviteListItem id={chat.kegDbId} chat={chat} channelName={chat.channelName} />;
     channelItem = (chat) => <ChannelListItem chat={chat} channelName={chat.name} />;
-    dmItem = (chat) => <ChatListItem key={chat.id} chat={chat} />;
+    dmItem = (chat) => <ChatListItem height={vars.listItemHeight} key={chat.id} chat={chat} />;
     renderListItem = (item) => {
         if (item.kegDbId) return this.inviteItem(item);
         if (item.isChannel) return this.channelItem(item);
@@ -136,6 +136,34 @@ export default class ChatList extends SafeComponent {
         if (!chat.id && !chat.kegDbId && !chat.spaceId && !chat.sectionTitle) return null;
 
         return this.renderListItem(chat);
+    };
+
+    getItemLayout = (data, index) => {
+        let offset = 0;
+        const { firstSectionItems, secondSectionItems } = this;
+        // first item is a section header
+        const firstSectionLength = firstSectionItems.length ?
+            firstSectionItems.length + 1 : 0;
+        // first section
+        if (firstSectionLength) {
+            offset += Math.min(index, firstSectionLength) * vars.sectionHeaderHeight;
+        }
+        // first item is a section header
+        const secondSectionLength = secondSectionItems.length ?
+            secondSectionItems.length + 1 : 0;
+        if (secondSectionLength) {
+            if (index > firstSectionLength) {
+                offset += vars.sectionHeaderHeight;
+            }
+            offset += Math.max(0, index - 1 - firstSectionLength) * vars.listItemHeight;
+        }
+
+        const length = index > firstSectionLength ? vars.listItemHeight : vars.sectionHeaderHeight;
+        return {
+            length,
+            offset,
+            index
+        };
     };
 
     @action.bound scrollViewRef(sv) {
@@ -219,7 +247,7 @@ export default class ChatList extends SafeComponent {
             minItemIndex = Math.min(minItemIndex, itemIndex);
             maxItemIndex = Math.max(maxItemIndex, itemIndex);
         });
-        console.log(`viewability changed: min: ${minItemIndex}, max: ${maxItemIndex}`);
+        // console.log(`viewability changed: min: ${minItemIndex}, max: ${maxItemIndex}`);
         Object.assign(this, { minItemIndex, maxItemIndex });
     }
 
@@ -235,6 +263,7 @@ export default class ChatList extends SafeComponent {
                 keyExtractor={this.keyExtractor}
                 onViewableItemsChanged={this.onViewableItemsChanged}
                 viewabilityConfig={viewabilityConfig}
+                getItemLayout={this.getItemLayout}
             />
         );
     }

--- a/app/components/messaging/chat-list.js
+++ b/app/components/messaging/chat-list.js
@@ -99,7 +99,7 @@ export default class ChatList extends SafeComponent {
             // TODO: unify this
             if (Platform.OS === 'android') {
                 // we don't do anything here because no indicator update is an iOS problem right now
-            } else {
+            } else if (this.scrollView && this.scrollView._wrapperListRef) {
                 this.scrollView._wrapperListRef._listRef.scrollToOffset({ offset: 0 });
             }
         }, 100);

--- a/app/components/messaging/chat-list.js
+++ b/app/components/messaging/chat-list.js
@@ -79,10 +79,13 @@ export default class ChatList extends SafeComponent {
             this.reverseRoomSorting = !this.reverseRoomSorting;
         };
 
-        this.indicatorReaction = reaction(() => [
-            this.topIndicatorVisible,
-            this.bottomIndicatorVisible
-        ], transitionAnimation, { fireImmediately: true });
+        // android has buggy overlay if you trigger animation immediately
+        if (Platform.OS !== 'android') {
+            this.indicatorReaction = reaction(() => [
+                this.topIndicatorVisible,
+                this.bottomIndicatorVisible
+            ], transitionAnimation, { fireImmediately: true });
+        }
     }
 
     componentWillUnmount() {
@@ -229,7 +232,7 @@ export default class ChatList extends SafeComponent {
             ++i;
         }
         this.maxItemIndex = Math.max(this.minItemIndex, i - 1);
-    };
+    }
 
     get listView() {
         if (chatState.routerMain.currentIndex !== 0) return null;

--- a/app/components/messaging/chat-state.js
+++ b/app/components/messaging/chat-state.js
@@ -10,7 +10,6 @@ class ChatState extends RoutedState {
     @observable store = chatStore;
     @observable chatInviteStore = chatInviteStore;
     @observable collapseChannels = false;
-    @observable collapseDMs = false;
     @observable selfNewMessageCounter = 0;
     LIMIT_PEOPLE_DM = 1;
 

--- a/app/components/mocks/index.js
+++ b/app/components/mocks/index.js
@@ -1,7 +1,7 @@
 // import MockBeacon from './beacons/mock-beacon';
 // import MockChannel from './mock-channel';
 /* import MockChannelCreate from './mock-channel-create'; */
-// import MockChatList from './mock-chat-list';
+import MockChatList from './mock-chat-list';
 // import MockTwoFactorAuth from './mock-two-factor-auth';
 // import Mock2FAPopup from './mock-2fa-popup';
 // import MockPopups from './mock-popups';
@@ -13,8 +13,8 @@
 // import MockPerfResults from './mock-perf-results';
 // import MockSqlTest from './mock-sql-test';
 
-export default null;
-// export default MockBeacon;
+// export default null;
+export default MockChatList;
 // export default MockSqlTest;
 // export default MockSignupContactInvite;
 // export default MockChannel;

--- a/app/components/mocks/index.js
+++ b/app/components/mocks/index.js
@@ -1,7 +1,7 @@
 // import MockBeacon from './beacons/mock-beacon';
 // import MockChannelView from './mock-channel-view';
 /* import MockChannelCreate from './mock-channel-create'; */
-import MockChatList from './mock-chat-list';
+// import MockChatList from './mock-chat-list';
 // import MockTwoFactorAuth from './mock-two-factor-auth';
 // import Mock2FAPopup from './mock-2fa-popup';
 // import MockPopups from './mock-popups';

--- a/app/components/mocks/index.js
+++ b/app/components/mocks/index.js
@@ -1,5 +1,5 @@
 // import MockBeacon from './beacons/mock-beacon';
-// import MockChannel from './mock-channel';
+// import MockChannelView from './mock-channel-view';
 /* import MockChannelCreate from './mock-channel-create'; */
 import MockChatList from './mock-chat-list';
 // import MockTwoFactorAuth from './mock-two-factor-auth';

--- a/app/components/mocks/index.js
+++ b/app/components/mocks/index.js
@@ -13,8 +13,8 @@ import MockChatList from './mock-chat-list';
 // import MockPerfResults from './mock-perf-results';
 // import MockSqlTest from './mock-sql-test';
 
-// export default null;
-export default MockChatList;
+export default null;
+// export default MockChatList;
 // export default MockSqlTest;
 // export default MockSignupContactInvite;
 // export default MockChannel;

--- a/app/components/mocks/mock-channel-view.js
+++ b/app/components/mocks/mock-channel-view.js
@@ -1,0 +1,149 @@
+import React, { Component } from 'react';
+import { View, StatusBar, Image } from 'react-native';
+import { observable, reaction } from 'mobx';
+import { observer } from 'mobx-react/native';
+import HeaderMain from '../layout/header-main';
+import Chat from '../messaging/chat';
+import ChannelInfo from '../messaging/channel-info';
+import PopupLayout from '../layout/popup-layout';
+import ChannelAddPeople from '../messaging/channel-add-people';
+import InputMainContainer from '../layout/input-main-container';
+import FileUploadProgress from '../files/file-upload-progress';
+import { User, clientApp, TinyDb } from '../../lib/icebear';
+import fileState from '../files/file-state';
+import chatState from '../messaging/chat-state';
+import contactState from '../contacts/contact-state';
+import mockContactStore from './mock-contact-store';
+import mockChatStore from './mock-chat-store';
+import mockFileStore from './mock-file-store';
+import routerMain from '../routes/router-main';
+import routerModal from '../routes/router-modal';
+
+@observer
+export default class MockChannel extends Component {
+    @observable showChannelInfo = false;
+    @observable showAddPeople = false;
+    @observable originalData = null;
+    @observable imagePath = null;
+
+    async componentWillMount() {
+        clientApp.uiUserPrefs.externalContentConsented = true;
+        clientApp.uiUserPrefs.externalContentEnabled = true;
+
+        User.current = { activePlans: [] };
+        mockFileStore.install();
+        contactState.store = mockContactStore;
+        chatState.store = mockChatStore;
+        chatState.addAck = () => {
+            chatState.store.activeChat.addInlineImageMessage();
+        };
+        chatState.addMessage = message => {
+            chatState.store.activeChat.addRandomMessage(message);
+        };
+        fileState.uploadInline = async path => {
+            console.log(path);
+            chatState.store.activeChat.addInlineImageMessageFromFile(path);
+        };
+        routerMain.current = observable({
+            routeState: observable({
+                title: '# channel-mock',
+                titleAction: () => { this.showChannelInfo = true; }
+            })
+        });
+        const discard = routerModal.discard.bind(routerModal);
+        routerModal.discard = () => {
+            this.showChannelInfo = false;
+            this.showAddPeople = false;
+            if (routerModal.route === 'channelAddPeople') {
+                this.showChannelInfo = true;
+            }
+            discard();
+        };
+
+        reaction(() => routerModal.route, route => {
+            if (route === 'channelAddPeople') {
+                this.showChannelInfo = false;
+                this.showAddPeople = true;
+            }
+        });
+
+        this.imagePath = await TinyDb.system.getValue('mock-thumbnail');
+        fileState.localFileMap.set(1, this.imagePath);
+        fileState.localFileMap.set(2, this.imagePath);
+    }
+
+    componentDidMount() {
+        setInterval(() => {
+            this.progress += 10;
+            if (this.progress > this.progressMax) {
+                this.progress = 0;
+            }
+        }, 1000);
+    }
+
+    get channelList() {
+        return (
+            <View style={{ backgroundColor: 'white', flex: 1, flexGrow: 1 }}>
+                <HeaderMain />
+                <Chat />
+                <StatusBar barStyle="light-content" />
+            </View>
+        );
+    }
+
+    get channelInfo() {
+        return (
+            <View style={{ backgroundColor: 'white', flex: 1, flexGrow: 1 }}>
+                <ChannelInfo />
+                <StatusBar barStyle="default" />
+            </View>
+        );
+    }
+
+    get addPeople() {
+        return (
+            <View style={{ backgroundColor: 'white', flex: 1, flexGrow: 1 }}>
+                <ChannelAddPeople />
+                <StatusBar barStyle="default" />
+            </View>
+        );
+    }
+
+    get body() {
+        if (this.showChannelInfo) return this.channelInfo;
+        if (this.showAddPeople) return this.addPeople;
+        return this.channelList;
+    }
+
+    @observable progressMax = 100;
+    @observable progress = 90;
+
+    get progressBar() {
+        const { progressMax, progress } = this;
+        const file = { fileId: 1, progressMax, progress, ext: 'jpg' };
+        const title = 'Caaaaaaat1 very long title which grows forever and ever.jpg';
+        return <FileUploadProgress file={file} title={title} />;
+    }
+
+    get image() {
+        const { originalData } = this;
+        if (!originalData) return null;
+        const s = {
+            width: 100,
+            height: 100
+        };
+        return <Image style={s} source={{ uri: `data:image/png;base64,${originalData}` }} />;
+    }
+
+    render() {
+        return (
+            <View style={{ flex: 1, flexGrow: 1 }}>
+                {this.body}
+                {this.image}
+                {this.progressBar}
+                <InputMainContainer canSend />
+                <PopupLayout key="popups" />
+            </View>
+        );
+    }
+}

--- a/app/components/mocks/mock-channel.js
+++ b/app/components/mocks/mock-channel.js
@@ -37,10 +37,8 @@ class MockChannel {
 
     constructor() {
         TinyDb.userCollection = TinyDb.open('testuser');
-        for (let i = 0; i < 8; ++i) this.participants.push(mockContactStore.createMock());
+        this.initParticipants();
         this.id = randomWords({ min: 7, max: 7, join: ':' });
-        this.addAdmin(this.participants[0]);
-        this.addAdmin(this.participants[1]);
 
         for (let i = 0; i < 10; ++i) {
             this.addInlineImageMessage();
@@ -48,6 +46,12 @@ class MockChannel {
         }
         // this.addInlineImageMessage();
         // this.addExternalUrlMessage();
+    }
+
+    initParticipants() {
+        for (let i = 0; i < 8; ++i) this.participants.push(mockContactStore.createMock());
+        this.addAdmin(this.participants[0]);
+        this.addAdmin(this.participants[1]);
     }
 
     toggleFavoriteState() {

--- a/app/components/mocks/mock-channel.js
+++ b/app/components/mocks/mock-channel.js
@@ -1,149 +1,140 @@
-import React, { Component } from 'react';
-import { View, StatusBar, Image } from 'react-native';
-import { observable, reaction } from 'mobx';
-import { observer } from 'mobx-react/native';
-import HeaderMain from '../layout/header-main';
-import Chat from '../messaging/chat';
-import ChannelInfo from '../messaging/channel-info';
-import PopupLayout from '../layout/popup-layout';
-import ChannelAddPeople from '../messaging/channel-add-people';
-import InputMainContainer from '../layout/input-main-container';
-import FileUploadProgress from '../files/file-upload-progress';
-import { User, clientApp, TinyDb } from '../../lib/icebear';
-import fileState from '../files/file-state';
-import chatState from '../messaging/chat-state';
-import contactState from '../contacts/contact-state';
+import { observable } from 'mobx';
+import randomWords from 'random-words';
+import capitalize from 'capitalize';
 import mockContactStore from './mock-contact-store';
-import mockChatStore from './mock-chat-store';
 import mockFileStore from './mock-file-store';
-import routerMain from '../routes/router-main';
-import routerModal from '../routes/router-modal';
+import { TinyDb } from '../../lib/icebear';
 
-@observer
-export default class MockChannel extends Component {
-    @observable showChannelInfo = false;
-    @observable showAddPeople = false;
-    @observable originalData = null;
-    @observable imagePath = null;
+const randomImages = [
+    'https://i.ytimg.com/vi/xC5n8f0fTeE/maxresdefault.jpg',
+    'http://cdn-image.travelandleisure.com/sites/default/files/styles/1600x1000/public/1487095116/forest-park-portland-oregon-FORESTBATH0217.jpg?itok=XVmUfPQB',
+    'http://cdn-image.travelandleisure.com/sites/default/files/styles/1600x1000/public/1487095116/yakushima-forest-japan-FORESTBATH0217.jpg?itok=mnXAvDq3',
+    'http://25.media.tumblr.com/865fb0f33ebdde6360be8576ad6b1978/tumblr_n08zcnLOEf1t8zamio1_250.png',
+    'http://globalforestlink.com/wp-content/uploads/2015/07/coniferous.jpg',
+    'https://upload.wikimedia.org/wikipedia/commons/thumb/8/8c/Grand_Anse_Beach_Grenada.jpg/1200px-Grand_Anse_Beach_Grenada.jpg',
+    'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcS5RzVGnDGecjd0b7YqxzvkkRo-6jiraf9FOMQAgChfa4WKD_6c',
+    'http://www.myjerseyshore.com/wp-content/themes/directorypress/thumbs//Beaches-Page-Picture.jpg',
+    'http://www.shoreexcursionsgroup.com/img/article/region_bermuda2.jpg'
+];
 
-    async componentWillMount() {
-        clientApp.uiUserPrefs.externalContentConsented = true;
-        clientApp.uiUserPrefs.externalContentEnabled = true;
+class MockChannel {
+    @observable messages = [];
+    @observable id;
+    @observable isChannel = true;
+    @observable name = randomWords({ min: 1, max: 4, join: '-' });
+    @observable topic = `${capitalize(randomWords({ min: 2, max: 4, join: ' ' }))}!`;
+    @observable participants = [];
+    @observable isFavorite = false;
+    @observable isMuted = false;
+    @observable adminMap = observable.map();
+    @observable loaded = true;
+    @observable unreadCount = 0;
+    @observable headLoaded = true;
 
-        User.current = { activePlans: [] };
-        mockFileStore.install();
-        contactState.store = mockContactStore;
-        chatState.store = mockChatStore;
-        chatState.addAck = () => {
-            chatState.store.activeChat.addInlineImageMessage();
-        };
-        chatState.addMessage = message => {
-            chatState.store.activeChat.addRandomMessage(message);
-        };
-        fileState.uploadInline = async path => {
-            console.log(path);
-            chatState.store.activeChat.addInlineImageMessageFromFile(path);
-        };
-        routerMain.current = observable({
-            routeState: observable({
-                title: '# channel-mock',
-                titleAction: () => { this.showChannelInfo = true; }
-            })
+    get allJoinedParticipants() { return this.participants; }
+    get otherParticipants() { return this.participants; }
+
+
+    constructor() {
+        TinyDb.userCollection = TinyDb.open('testuser');
+        for (let i = 0; i < 8; ++i) this.participants.push(mockContactStore.createMock());
+        this.id = randomWords({ min: 7, max: 7, join: ':' });
+        this.addAdmin(this.participants[0]);
+        this.addAdmin(this.participants[1]);
+
+        for (let i = 0; i < 10; ++i) {
+            this.addInlineImageMessage();
+            // this.addRandomMessage();
+        }
+        // this.addInlineImageMessage();
+        // this.addExternalUrlMessage();
+    }
+
+    toggleFavoriteState() {
+        this.isFavorite = !this.isFavorite;
+    }
+
+    toggleMuted() {
+        this.isMuted = !this.isMuted;
+    }
+
+    removeChannelMember(contact) {
+        const i = this.participants.indexOf(contact);
+        if (i !== -1) this.participants.splice(i, 1);
+    }
+
+    isAdmin(contact) {
+        return this.adminMap.has(contact.username);
+    }
+
+    addAdmin(contact) {
+        this.adminMap.set(contact.username, contact);
+    }
+
+    removeAdmin(contact) {
+        this.adminMap.delete(contact.username);
+    }
+
+    sendInvites(contacts) {
+        contacts.forEach(i => {
+            if (this.participants.filter(p => p.username === i.username).length === 0) {
+                this.participants.push(i);
+            }
         });
-        const discard = routerModal.discard.bind(routerModal);
-        routerModal.discard = () => {
-            this.showChannelInfo = false;
-            this.showAddPeople = false;
-            if (routerModal.route === 'channelAddPeople') {
-                this.showChannelInfo = true;
-            }
-            discard();
-        };
-
-        reaction(() => routerModal.route, route => {
-            if (route === 'channelAddPeople') {
-                this.showChannelInfo = false;
-                this.showAddPeople = true;
-            }
-        });
-
-        this.imagePath = await TinyDb.system.getValue('mock-thumbnail');
-        fileState.localFileMap.set(1, this.imagePath);
-        fileState.localFileMap.set(2, this.imagePath);
     }
 
-    componentDidMount() {
-        setInterval(() => {
-            this.progress += 10;
-            if (this.progress > this.progressMax) {
-                this.progress = 0;
-            }
-        }, 1000);
+    createMock(message) {
+        const id = randomWords({ min: 1, max: 4, join: '-' });
+        let text = message;
+        if (!message && message !== false) text = randomWords({ min: 1, max: 4, join: ' ' });
+        const sender = this.participants[0];
+        const groupWithPrevious = Math.random() > 0.5;
+        return { id, text, sender, groupWithPrevious };
     }
 
-    get channelList() {
-        return (
-            <View style={{ backgroundColor: 'white', flex: 1, flexGrow: 1 }}>
-                <HeaderMain />
-                <Chat />
-                <StatusBar barStyle="light-content" />
-            </View>
-        );
+    addRandomMessage(message) {
+        const m = this.createMock(message);
+        this.messages.push(m);
     }
 
-    get channelInfo() {
-        return (
-            <View style={{ backgroundColor: 'white', flex: 1, flexGrow: 1 }}>
-                <ChannelInfo />
-                <StatusBar barStyle="default" />
-            </View>
-        );
+    addInlineImageMessage() {
+        const m = this.createMock(false);
+        const name = `${randomWords({ min: 8, max: 12, join: '_' })}.png`;
+        const url = randomImages.random();
+        m.hasUrls = true;
+        m.externalImages = [{ url, name, oversized: true /* , fileId: 1 */ }];
+        this.messages.push(m);
     }
 
-    get addPeople() {
-        return (
-            <View style={{ backgroundColor: 'white', flex: 1, flexGrow: 1 }}>
-                <ChannelAddPeople />
-                <StatusBar barStyle="default" />
-            </View>
-        );
+    addExternalUrlMessage() {
+        const m = this.createMock('https://eslint.org/docs/rules/operator-assignment');
+        const name = `${randomWords({ min: 1, max: 2, join: '_' })}.png`;
+        const title = capitalize(randomWords({ min: 3, max: 5, join: ' ' }));
+        const description = capitalize(randomWords({ min: 5, max: 10, join: ' ' }));
+        const url = randomImages.random();
+        m.inlineImage = { url, name, title, description, isLocal: false };
+        this.messages.push(m);
     }
 
-    get body() {
-        if (this.showChannelInfo) return this.channelInfo;
-        if (this.showAddPeople) return this.addPeople;
-        return this.channelList;
+    addFileMessage() {
+        const m = this.createMock(false);
+        m.files = [mockFileStore.files[0].id];
+        this.messages.push(m);
     }
 
-    @observable progressMax = 100;
-    @observable progress = 90;
-
-    get progressBar() {
-        const { progressMax, progress } = this;
-        const file = { fileId: 1, progressMax, progress, ext: 'jpg' };
-        const title = 'Caaaaaaat1 very long title which grows forever and ever.jpg';
-        return <FileUploadProgress file={file} title={title} />;
+    async addInlineImageMessageFromFile(path) {
+        const m = this.createMock(false);
+        const name = `${randomWords({ min: 1, max: 2, join: '_' })}.png`;
+        const url = path;
+        m.inlineImage = { url, name, isLocal: true };
+        this.messages.push(m);
     }
 
-    get image() {
-        const { originalData } = this;
-        if (!originalData) return null;
-        const s = {
-            width: 100,
-            height: 100
-        };
-        return <Image style={s} source={{ uri: `data:image/png;base64,${originalData}` }} />;
-    }
-
-    render() {
-        return (
-            <View style={{ flex: 1, flexGrow: 1 }}>
-                {this.body}
-                {this.image}
-                {this.progressBar}
-                <InputMainContainer canSend />
-                <PopupLayout key="popups" />
-            </View>
-        );
+    get uploadQueue() {
+        const f = mockFileStore.files[0];
+        f.uploading = true;
+        return [f];
     }
 }
+
+export default MockChannel;

--- a/app/components/mocks/mock-chat-list.js
+++ b/app/components/mocks/mock-chat-list.js
@@ -18,7 +18,6 @@ import mockContactStore from './mock-contact-store';
 import mockFileStore from './mock-file-store';
 import TabContainer from '../layout/tab-container';
 import { TopDrawerMaintenance, /* TopDrawerNewContact, */ TopDrawerPendingFiles, TopDrawerAutoMount } from '../shared/top-drawer-components';
-import { observable } from '../../../node_modules/mobx/lib/mobx';
 
 const button = {
     position: 'absolute',
@@ -59,15 +58,13 @@ const remove = [
 @observer
 export default class MockChatList extends Component {
     componentWillMount() {
-        User.current = mockContactStore.createMock();
-        User.current.activePlans = [];
-        User.current.beacons = observable.map();
-        User.current.saveBeacons = () => {};
+        User.current = mockContactStore.createMockCurrentUser();
         mockFileStore.install();
         chatState.store = mockChatStore;
         chatState.init();
         contactState.store = mockContactStore;
         contactState.init();
+        global.chatState = chatState;
     }
 
     addGlobalDrawer = () => {

--- a/app/components/mocks/mock-chat-list.js
+++ b/app/components/mocks/mock-chat-list.js
@@ -64,7 +64,9 @@ export default class MockChatList extends Component {
         chatState.init();
         contactState.store = mockContactStore;
         contactState.init();
-        global.chatState = chatState;
+        const { chats } = chatState.store;
+        chats[0].unreadCount = 2;
+        chats[chats.length - 1].unreadCount = 3;
     }
 
     addGlobalDrawer = () => {

--- a/app/components/mocks/mock-chat-list.js
+++ b/app/components/mocks/mock-chat-list.js
@@ -18,6 +18,7 @@ import mockContactStore from './mock-contact-store';
 import mockFileStore from './mock-file-store';
 import TabContainer from '../layout/tab-container';
 import { TopDrawerMaintenance, /* TopDrawerNewContact, */ TopDrawerPendingFiles, TopDrawerAutoMount } from '../shared/top-drawer-components';
+import { observable } from '../../../node_modules/mobx/lib/mobx';
 
 const button = {
     position: 'absolute',
@@ -60,6 +61,8 @@ export default class MockChatList extends Component {
     componentWillMount() {
         User.current = mockContactStore.createMock();
         User.current.activePlans = [];
+        User.current.beacons = observable.map();
+        User.current.saveBeacons = () => {};
         mockFileStore.install();
         chatState.store = mockChatStore;
         chatState.init();
@@ -93,18 +96,13 @@ export default class MockChatList extends Component {
             case 'files':
                 return <Files />;
             default:
-                return <Files />;
+                return <ChatList />;
         }
     }
 
-    render() {
+    get drawerControl() {
         return (
-            <View style={{ backgroundColor: 'white', flex: 1, flexGrow: 1, paddingTop: vars.layoutPaddingTop }}>
-                <TabContainer />
-                {this.list}
-                <PopupLayout key="popups" />
-                <StatusBar barStyle="default" />
-                <TabContainer />
+            <View>
                 <TouchableOpacity
                     style={add1}
                     onPress={this.addGlobalDrawer}
@@ -132,6 +130,17 @@ export default class MockChatList extends Component {
                         Delete
                     </Text>
                 </TouchableOpacity>
+            </View>
+        );
+    }
+
+    render() {
+        return (
+            <View style={{ backgroundColor: 'white', flex: 1, flexGrow: 1, paddingTop: vars.layoutPaddingTop }}>
+                {this.list}
+                <TabContainer />
+                <PopupLayout key="popups" />
+                <StatusBar barStyle="default" />
                 <TopDrawerAutoMount />
             </View>
         );

--- a/app/components/mocks/mock-chat-store.js
+++ b/app/components/mocks/mock-chat-store.js
@@ -21,11 +21,11 @@ class MockChatStore {
     get allRooms() { return this.channels; }
 
     constructor() {
-        for (let i = 0; i < 5; ++i) {
+        for (let i = 0; i < 55; ++i) {
             this.chats.push(this.createMockChannel());
         }
 
-        for (let i = 0; i < 15; ++i) {
+        for (let i = 0; i < 155; ++i) {
             this.chats.push(this.createMock());
         }
 

--- a/app/components/mocks/mock-chat-store.js
+++ b/app/components/mocks/mock-chat-store.js
@@ -21,11 +21,11 @@ class MockChatStore {
     get allRooms() { return this.channels; }
 
     constructor() {
-        for (let i = 0; i < 55; ++i) {
+        for (let i = 0; i < 15; ++i) {
             this.chats.push(this.createMockChannel());
         }
 
-        for (let i = 0; i < 155; ++i) {
+        for (let i = 0; i < 125; ++i) {
             this.chats.push(this.createMock());
         }
 

--- a/app/components/mocks/mock-chat-store.js
+++ b/app/components/mocks/mock-chat-store.js
@@ -1,150 +1,14 @@
 import { observable, computed } from 'mobx';
 import randomWords from 'random-words';
-import capitalize from 'capitalize';
 import mockContactStore from './mock-contact-store';
-import mockFileStore from './mock-file-store';
 import { popupCancelConfirm } from '../shared/popups';
-import { TinyDb } from '../../lib/icebear';
+import MockChannel from './mock-channel';
+import MockChat from './mock-chat';
 
 const channelPaywallTitle = `2 Channels`;
 const channelPaywallMessage =
 `Peerio's basic account gets you access to 2 free channels.
 If you would like to join or create another channel, please delete an existing one or check out our upgrade plans`;
-
-const randomImages = [
-    'https://i.ytimg.com/vi/xC5n8f0fTeE/maxresdefault.jpg',
-    'http://cdn-image.travelandleisure.com/sites/default/files/styles/1600x1000/public/1487095116/forest-park-portland-oregon-FORESTBATH0217.jpg?itok=XVmUfPQB',
-    'http://cdn-image.travelandleisure.com/sites/default/files/styles/1600x1000/public/1487095116/yakushima-forest-japan-FORESTBATH0217.jpg?itok=mnXAvDq3',
-    'http://25.media.tumblr.com/865fb0f33ebdde6360be8576ad6b1978/tumblr_n08zcnLOEf1t8zamio1_250.png',
-    'http://globalforestlink.com/wp-content/uploads/2015/07/coniferous.jpg',
-    'https://upload.wikimedia.org/wikipedia/commons/thumb/8/8c/Grand_Anse_Beach_Grenada.jpg/1200px-Grand_Anse_Beach_Grenada.jpg',
-    'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcS5RzVGnDGecjd0b7YqxzvkkRo-6jiraf9FOMQAgChfa4WKD_6c',
-    'http://www.myjerseyshore.com/wp-content/themes/directorypress/thumbs//Beaches-Page-Picture.jpg',
-    'http://www.shoreexcursionsgroup.com/img/article/region_bermuda2.jpg'
-];
-
-class MockChannel {
-    @observable messages = [];
-    @observable id;
-    @observable isChannel = true;
-    @observable name = randomWords({ min: 1, max: 4, join: '-' });
-    @observable topic = `${capitalize(randomWords({ min: 2, max: 4, join: ' ' }))}!`;
-    @observable participants = [];
-    @observable isFavorite = false;
-    @observable isMuted = false;
-    @observable adminMap = observable.map();
-    @observable loaded = true;
-    @observable unreadCount = 0;
-
-    get allJoinedParticipants() { return this.participants; }
-    get otherParticipants() { return this.participants; }
-
-
-    constructor() {
-        TinyDb.userCollection = TinyDb.open('testuser');
-        for (let i = 0; i < 8; ++i) this.participants.push(mockContactStore.createMock());
-        this.id = randomWords({ min: 7, max: 7, join: ':' });
-        this.addAdmin(this.participants[0]);
-        this.addAdmin(this.participants[1]);
-
-        for (let i = 0; i < 10; ++i) {
-            this.addInlineImageMessage();
-            // this.addRandomMessage();
-        }
-        // this.addInlineImageMessage();
-        // this.addExternalUrlMessage();
-    }
-
-    toggleFavoriteState() {
-        this.isFavorite = !this.isFavorite;
-    }
-
-    toggleMuted() {
-        this.isMuted = !this.isMuted;
-    }
-
-    removeChannelMember(contact) {
-        const i = this.participants.indexOf(contact);
-        if (i !== -1) this.participants.splice(i, 1);
-    }
-
-    isAdmin(contact) {
-        return this.adminMap.has(contact.username);
-    }
-
-    addAdmin(contact) {
-        this.adminMap.set(contact.username, contact);
-    }
-
-    removeAdmin(contact) {
-        this.adminMap.delete(contact.username);
-    }
-
-    sendInvites(contacts) {
-        contacts.forEach(i => {
-            if (this.participants.filter(p => p.username === i.username).length === 0) {
-                this.participants.push(i);
-            }
-        });
-    }
-
-    createMock(message) {
-        const id = randomWords({ min: 1, max: 4, join: '-' });
-        let text = message;
-        if (!message && message !== false) text = randomWords({ min: 1, max: 4, join: ' ' });
-        const sender = this.participants[0];
-        const groupWithPrevious = Math.random() > 0.5;
-        return { id, text, sender, groupWithPrevious };
-    }
-
-    addRandomMessage(message) {
-        const m = this.createMock(message);
-        this.messages.push(m);
-    }
-
-    addInlineImageMessage() {
-        const m = this.createMock(false);
-        const name = `${randomWords({ min: 8, max: 12, join: '_' })}.png`;
-        const url = randomImages.random();
-        m.hasUrls = true;
-        m.externalImages = [{ url, name, oversized: true /* , fileId: 1 */ }];
-        this.messages.push(m);
-    }
-
-    addExternalUrlMessage() {
-        const m = this.createMock('https://eslint.org/docs/rules/operator-assignment');
-        const name = `${randomWords({ min: 1, max: 2, join: '_' })}.png`;
-        const title = capitalize(randomWords({ min: 3, max: 5, join: ' ' }));
-        const description = capitalize(randomWords({ min: 5, max: 10, join: ' ' }));
-        const url = randomImages.random();
-        m.inlineImage = { url, name, title, description, isLocal: false };
-        this.messages.push(m);
-    }
-
-    addFileMessage() {
-        const m = this.createMock(false);
-        m.files = [mockFileStore.files[0].id];
-        this.messages.push(m);
-    }
-
-    async addInlineImageMessageFromFile(path) {
-        const m = this.createMock(false);
-        const name = `${randomWords({ min: 1, max: 2, join: '_' })}.png`;
-        const url = path;
-        m.inlineImage = { url, name, isLocal: true };
-        this.messages.push(m);
-    }
-
-    get uploadQueue() {
-        const f = mockFileStore.files[0];
-        f.uploading = true;
-        return [f];
-    }
-}
-
-class MockChat extends MockChannel {
-    @observable isChannel = false;
-}
 
 class MockChatStore {
     @observable chats = [];
@@ -153,6 +17,8 @@ class MockChatStore {
     @computed get channels() {
         return this.chats.filter(chat => chat.isChannel);
     }
+
+    get allRooms() { return this.channels; }
 
     constructor() {
         for (let i = 0; i < 5; ++i) {

--- a/app/components/mocks/mock-chat.js
+++ b/app/components/mocks/mock-chat.js
@@ -1,8 +1,15 @@
 import { observable } from 'mobx';
 import MockChannel from './mock-channel';
+import mockContactStore from './mock-contact-store';
 
 class MockChat extends MockChannel {
     @observable isChannel = false;
+    otherParticipants = [];
+
+    initParticipants() {
+        // exactly one participant
+        this.participants.push(mockContactStore.createMock());
+    }
 }
 
 export default MockChat;

--- a/app/components/mocks/mock-chat.js
+++ b/app/components/mocks/mock-chat.js
@@ -1,0 +1,8 @@
+import { observable } from 'mobx';
+import MockChannel from './mock-channel';
+
+class MockChat extends MockChannel {
+    @observable isChannel = false;
+}
+
+export default MockChat;

--- a/app/components/mocks/mock-contact-store.js
+++ b/app/components/mocks/mock-contact-store.js
@@ -1,6 +1,7 @@
 import randomWords from 'random-words';
 import capitalize from 'capitalize';
 import { observable } from 'mobx';
+import MockCurrentUser from './mock-current-user';
 
 class MockContactStore {
     addedContacts = [];
@@ -44,6 +45,13 @@ class MockContactStore {
         };
         this.contacts.push(contact);
         this.contactsMap.set(username, contact);
+        return contact;
+    }
+
+    createMockCurrentUser() {
+        const contact = new MockCurrentUser();
+        this.contacts.push(contact);
+        this.contactsMap.set(contact.username, contact);
         return contact;
     }
 

--- a/app/components/mocks/mock-contact-store.js
+++ b/app/components/mocks/mock-contact-store.js
@@ -56,7 +56,6 @@ class MockContactStore {
     }
 
     getContact(username) {
-        console.log(`get ${username}`);
         const r = this.contactsMap.get(username);
         return r || { username, loading: false, notFound: true };
     }

--- a/app/components/mocks/mock-current-user.js
+++ b/app/components/mocks/mock-current-user.js
@@ -1,0 +1,35 @@
+import randomWords from 'random-words';
+import capitalize from 'capitalize';
+import { observable } from 'mobx';
+
+class MockCurrentUser {
+    @observable firstName;
+    @observable lastName;
+    @observable username;
+    beacons = observable.map();
+    activePlans = [];
+
+    saveBeacons() {
+        console.log(`mock save beacons`);
+    }
+
+    constructor() {
+        const username = `${randomWords()}${this.contacts.length}`;
+        const firstName = capitalize(randomWords());
+        const lastName = capitalize(randomWords());
+        const address = `${randomWords()}@123.com`;
+        Object.assign(this, {
+            username,
+            firstName,
+            lastName,
+            addresses: [
+                address
+            ],
+            loading: false,
+            notFound: false,
+            fullName: `${firstName} ${lastName}`
+        });
+    }
+}
+
+export default MockCurrentUser;

--- a/app/components/mocks/mock-current-user.js
+++ b/app/components/mocks/mock-current-user.js
@@ -1,5 +1,3 @@
-import randomWords from 'random-words';
-import capitalize from 'capitalize';
 import { observable } from 'mobx';
 
 class MockCurrentUser {
@@ -8,16 +6,20 @@ class MockCurrentUser {
     @observable username;
     beacons = observable.map();
     activePlans = [];
+    settings = {
+        loaded: true
+    };
+    loading = false;
 
     saveBeacons() {
         console.log(`mock save beacons`);
     }
 
     constructor() {
-        const username = `${randomWords()}${this.contacts.length}`;
-        const firstName = capitalize(randomWords());
-        const lastName = capitalize(randomWords());
-        const address = `${randomWords()}@123.com`;
+        const username = `mockCurrentUser`;
+        const firstName = 'Current';
+        const lastName = 'User';
+        const address = `current@user.com`;
         Object.assign(this, {
             username,
             firstName,

--- a/app/components/shared/top-drawer.js
+++ b/app/components/shared/top-drawer.js
@@ -91,7 +91,7 @@ export default class TopDrawer extends SafeComponent {
     }
 }
 
-TopDrawer.PropTypes = {
+TopDrawer.propTypes = {
     context: PropTypes.string,
     heading: PropTypes.string.isRequired,
     image: PropTypes.any.isRequired,

--- a/ios/peeriomobile.xcodeproj/project.pbxproj
+++ b/ios/peeriomobile.xcodeproj/project.pbxproj
@@ -211,13 +211,6 @@
 			remoteGlobalIDString = 46FEDE7F1AFF192F00D3261C;
 			remoteInfo = RNMail;
 		};
-		020633CC2177FF8E00F5743C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41AF8F820E745F28DB9CABA /* RNMail.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 46FEDE8A1AFF192F00D3261C;
-			remoteInfo = RNMailTests;
-		};
 		020D12A021670C1D007484E3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 85F72AE1AB9C4B249FDE6333 /* RNFS.xcodeproj */;
@@ -308,13 +301,6 @@
 			proxyType = 2;
 			remoteGlobalIDString = 8C5379761FB471D100C1BC65;
 			remoteInfo = Lottie_tvOS;
-		};
-		022653CE213515BF003EEF56 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 1D58BC509EB240BF97F97E0E /* Lottie.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 62CA59B71E3C173B002D7188;
-			remoteInfo = Lottie_iOS;
 		};
 		0235B5D61E65DE24001D77D1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -832,7 +818,6 @@
 			isa = PBXGroup;
 			children = (
 				020633CB2177FF8E00F5743C /* libRNMail.a */,
-				020633CD2177FF8E00F5743C /* RNMailTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1257,7 +1242,6 @@
 			dependencies = (
 				0253B8111E6868F200554265 /* PBXTargetDependency */,
 				96CEC5A221107C3600F546CE /* PBXTargetDependency */,
-				022653CF213515BF003EEF56 /* PBXTargetDependency */,
 			);
 			name = peeriomobile;
 			productName = peeriomobile;
@@ -1596,13 +1580,6 @@
 			fileType = archive.ar;
 			path = libRNMail.a;
 			remoteRef = 020633CA2177FF8E00F5743C /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		020633CD2177FF8E00F5743C /* RNMailTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = RNMailTests.xctest;
-			remoteRef = 020633CC2177FF8E00F5743C /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		020D12A121670C1D007484E3 /* libRNFS.a */ = {
@@ -2053,11 +2030,6 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		022653CF213515BF003EEF56 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Lottie_iOS;
-			targetProxy = 022653CE213515BF003EEF56 /* PBXContainerItemProxy */;
-		};
 		0253B8111E6868F200554265 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = React;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "peeriomobile",
-  "version": "3.388.0",
+  "version": "3.389.0",
   "private": true,
   "scripts": {
     "postinstall": "./scripts/setup-env.sh && npm run icebear:compile && ./scripts/setup-rn-debugging.sh && ./scripts/copy-android-resources.sh && ./scripts/android-switch-to-rn-fork.sh && node scripts/test-deps.js",


### PR DESCRIPTION
#### Relevant info and issue/PR links 
 
https://app.clubhouse.io/peerio/story/15904/mobile-unread-message-bar-doesn-t-show-in-chat-list
https://app.clubhouse.io/peerio/story/15906/mobile-unread-message-bar-doesn-t-scroll

#### Testing instructions  

Login into account.
Receive messages in rooms or DMs which are invisible (offscreen). 
Check that unread indicators appear
Check that unread indicators appear after quickly switching between different routes (e.g. files-chats, files-chats) several times
Unread indicators must scroll precisely to the last or first unread item position, respectively.
Last unread item should be positioned at the bottom of the list, fully visible, after scroll.
First unread item should be positioned at the top of the list, fully visible, after scroll.
Unread indicators should appear when 80% of the unread item is invisible (cut off by render window).
Unread indicators should disappear when more than 20% of unread item is visible.
If there's a top drawer visible, scrolling should take into account the top drawer.

Possible regressions:
- chat list item height
- invite item height
- unread indicator animations
- top drawer positioning
- after-load list item rendering
- scrolling when top drawer is visible

Additional testing:

If you enable MockChatList in mocks/index.js, it is possible to easily test the scrolling behaviour on a big (200) list of items. It also enables guaranteed testing of scrolling to unrendered items. Generally, to scroll to unrendered items, you need at least 100 items in the list.

----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
