### PR TITLE
Fix telemetry share tracker

### DIFF
--- a/app/components/signup/signup-share-data.js
+++ b/app/components/signup/signup-share-data.js
@@ -43,17 +43,15 @@ export default class SignupShareData extends SafeComponent {
 
     @action.bound
     async handleShareButton() {
+        signupState.dataCollection = true;
         await this.finishAccountCreation();
-        User.current.saveSettings(settings => {
-            settings.errorTracking = true;
-            settings.dataCollection = true;
-        });
         tm.signup.shareData(true);
         tm.signup.finishSignup();
     }
 
     @action.bound
     async handleDeclineButton() {
+        signupState.dataCollection = false;
         await this.finishAccountCreation();
         tm.signup.shareData(false);
         tm.signup.finishSignup();

--- a/app/components/signup/signup-share-data.js
+++ b/app/components/signup/signup-share-data.js
@@ -8,7 +8,8 @@ import signupState from './signup-state';
 import { tx } from '../utils/translator';
 import SafeComponent from '../shared/safe-component';
 import buttons from '../helpers/buttons';
-import { User, telemetry } from '../../lib/icebear';
+import { User, telemetry  } from '../../lib/icebear';
+import { uiState } from '../states';
 import tm from '../../telemetry';
 
 const { S } = telemetry;
@@ -34,21 +35,29 @@ export default class SignupShareData extends SafeComponent {
     }
 
     @action.bound
-    handleShareButton() {
+    async finishAccountCreation() {
+        await signupState.finishAccountCreation();
+        await signupState.finishSignUp();
+        uiState.isFirstLogin = true;
+    }
+
+    @action.bound
+    async handleShareButton() {
+        await this.finishAccountCreation();
         User.current.saveSettings(settings => {
             settings.errorTracking = true;
             settings.dataCollection = true;
         });
         tm.signup.shareData(true);
         tm.signup.finishSignup();
-        signupState.finishSignUp();
+
     }
 
     @action.bound
-    handleDeclineButton() {
+    async handleDeclineButton() {
+        await this.finishAccountCreation();
         tm.signup.shareData(false);
         tm.signup.finishSignup();
-        signupState.finishSignUp();
     }
 
     renderThrow() {
@@ -65,7 +74,7 @@ export default class SignupShareData extends SafeComponent {
                         {buttons.blueTextButton(
                             tx('button_notNow'),
                             this.handleDeclineButton,
-                            null,
+                            User.current,
                             null,
                             'button_notNow'
                         )}
@@ -73,7 +82,7 @@ export default class SignupShareData extends SafeComponent {
                         {buttons.roundBlueBgButton(
                             tx('button_share'),
                             this.handleShareButton,
-                            null,
+                            User.current,
                             'button_share'
                         )}
                     </View>

--- a/app/components/signup/signup-share-data.js
+++ b/app/components/signup/signup-share-data.js
@@ -8,7 +8,7 @@ import signupState from './signup-state';
 import { tx } from '../utils/translator';
 import SafeComponent from '../shared/safe-component';
 import buttons from '../helpers/buttons';
-import { User, telemetry  } from '../../lib/icebear';
+import { User, telemetry } from '../../lib/icebear';
 import { uiState } from '../states';
 import tm from '../../telemetry';
 
@@ -50,7 +50,6 @@ export default class SignupShareData extends SafeComponent {
         });
         tm.signup.shareData(true);
         tm.signup.finishSignup();
-
     }
 
     @action.bound

--- a/app/components/signup/signup-state.js
+++ b/app/components/signup/signup-state.js
@@ -50,6 +50,7 @@ class SignupState extends RoutedState {
     @observable medicalId = '';
     @observable usernameSuggestions = [];
     @observable subscribeToPromoEmails = false;
+    @observable dataCollection = false;
     @observable isPdfPreviewVisible = false;
 
     get isFirst() {
@@ -164,6 +165,7 @@ class SignupState extends RoutedState {
             avatarBuffers,
             keyBackedUp,
             subscribeToPromoEmails,
+            dataCollection,
             country,
             specialty,
             role,
@@ -201,6 +203,7 @@ class SignupState extends RoutedState {
                     () => !settings.loading,
                     () => {
                         settings.subscribeToPromoEmails = subscribeToPromoEmails;
+                        settings.dataCollection = dataCollection;
                         User.current.saveSettings();
                     }
                 );

--- a/app/components/signup/signup-tos.js
+++ b/app/components/signup/signup-tos.js
@@ -10,7 +10,7 @@ import SafeComponent from '../shared/safe-component';
 import buttons from '../helpers/buttons';
 import ViewWithDrawer from '../shared/view-with-drawer';
 import { TopDrawerBackupAccountKey } from '../shared/top-drawer-components';
-import { drawerState, uiState } from '../states';
+import { drawerState } from '../states';
 import { socket, telemetry } from '../../lib/icebear';
 import routes from '../routes/routes';
 import TosAccordion from './tos-accordion';
@@ -65,10 +65,8 @@ export default class SignupTos extends SafeComponent {
     }
 
     @action.bound
-    async finishSignup() {
+    finishSignup() {
         tm.signup.acceptTos();
-        await signupState.finishAccountCreation();
-        uiState.isFirstLogin = true;
         signupState.next();
     }
 


### PR DESCRIPTION
#### Relevant info and issue/PR links 
https://app.clubhouse.io/peerio/story/17328/mobile-mixpanel-share-data-tracker
#### Testing instructions  
Please verify that when creating an account:
1- If user selects "Share Data", ALL telemetry events related to creating an account are sent (Including the share data tracker and the finish account creation one)
2- If user selects "Do not share", NO telemetry events are sent.


----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
