### PR TITLE
chore: fix download and reissue 2fa codes [ch18306]

### DIFF
--- a/app/components/settings/two-factor-auth-codes-generate.js
+++ b/app/components/settings/two-factor-auth-codes-generate.js
@@ -44,9 +44,9 @@ export default class TwoFactorAuthCodesGenerate extends SafeComponent {
         routes.main.settings('security');
     }
 
-    async reissueCodes() {
+    reissueCodes = async () => {
         this.backupCodes = await User.current.reissueBackupCodes();
-    }
+    };
 
     renderThrow() {
         if (this.backupCodes) return <TwoFactorAuthCodes codes={this.backupCodes} />;

--- a/app/components/settings/two-factor-auth-codes.js
+++ b/app/components/settings/two-factor-auth-codes.js
@@ -97,7 +97,7 @@ export default class TwoFactorAuthCodes extends SafeComponent {
         return result;
     }
 
-    async downloadCodes() {
+    downloadCodes = async () => {
         let mimeType = 'application/pdf';
         let filePath = '';
 
@@ -114,7 +114,7 @@ export default class TwoFactorAuthCodes extends SafeComponent {
         console.log(filePath);
         await FileOpener.open(filePath, mimeType, '2fa');
         // await RNFS.unlink(filePath);
-    }
+    };
 
     disable2fa() {
         User.current.disable2fa();


### PR DESCRIPTION
#### Relevant info and issue/PR links 

https://app.clubhouse.io/peerio/story/18306/mobile-download-2fa-backup-codes-and-generate-new-codes-buttons-are-broken
 
#### Testing instructions  

Download backup codes and generate new codes for 2fa should work now.

----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
