### PR TITLE
feat: add unshare inline files capability to file action sheet [ch18323]

### DIFF
--- a/app/components/files/file-action-sheet.js
+++ b/app/components/files/file-action-sheet.js
@@ -10,7 +10,8 @@ import { popupFileRename } from '../shared/popups';
 import snackbarState from '../snackbars/snackbar-state';
 
 export default class FileActionSheet {
-    static async show(file, fileAutoOpen, routeAfterDelete) {
+    static async show(params) {
+        const { file, fileAutoOpen, routeAfterDelete, canUnshare } = params;
         // TODO: remove when SDK is ready and/or move to SDK
         try {
             if (await config.FileStream.exists(file.tmpCachePath)) {
@@ -103,6 +104,17 @@ export default class FileActionSheet {
                 if (newFileName) await file.rename(`${newFileName}.${file.ext}`);
             }
         });
+
+        // Unshare
+        canUnshare &&
+            file.owner === User.current.username &&
+            actionButtons.push({
+                title: 'button_unshare',
+                action: async () => {
+                    await fileState.unshareFile(file);
+                    ActionSheetLayout.hide();
+                }
+            });
 
         // Delete
         actionButtons.push({

--- a/app/components/files/file-detail-view.js
+++ b/app/components/files/file-detail-view.js
@@ -41,7 +41,11 @@ export default class FileDetailView extends SafeComponent {
     }
 
     get rightIcon() {
-        return <MenuIcon action={() => FileActionSheet.show(this.file, false, 'files')} />;
+        return (
+            <MenuIcon
+                action={() => FileActionSheet.show({ file: this.file, routeAfterDelete: 'files' })}
+            />
+        );
     }
 
     get enabled() {

--- a/app/components/files/file-state.js
+++ b/app/components/files/file-state.js
@@ -61,6 +61,11 @@ class FileState extends RoutedState {
     }
 
     @action
+    async unshareFile(file) {
+        return file.remove();
+    }
+
+    @action
     async deleteFile(fileInfo) {
         const id = fileInfo.fileId;
         let file = fileStore.getById(id);

--- a/app/components/files/files.js
+++ b/app/components/files/files.js
@@ -100,7 +100,7 @@ export default class Files extends SafeComponent {
                 file={item}
                 rowID={index}
                 onChangeFolder={this.onChangeFolder}
-                onFileAction={() => FileActionSheet.show(item)}
+                onFileAction={() => FileActionSheet.show({ file: item })}
                 onFolderAction={() => FoldersActionSheet.show(item)}
             />
         );

--- a/app/components/files/recent-files-list.js
+++ b/app/components/files/recent-files-list.js
@@ -30,7 +30,7 @@ export default class RecentFilesList extends SafeComponent {
         // for event handler
         return (
             <RecentFileItem
-                onMenu={() => FileActionSheet.show(item, false)}
+                onMenu={() => FileActionSheet.show({ file: item })}
                 key={item.fileId}
                 file={item}
             />

--- a/app/components/messaging/chat.js
+++ b/app/components/messaging/chat.js
@@ -110,9 +110,10 @@ export default class Chat extends SafeComponent {
             ref: ref => {
                 this._refs[key] = ref;
             },
-            onInlineImageAction: image => FileActionSheet.show(image),
-            onLegacyFileAction: file => FileActionSheet.show(file),
-            onFileAction: file => FileActionSheet.show(file, true)
+            onInlineImageAction: image => FileActionSheet.show({ file: image, canUnshare: true }),
+            onLegacyFileAction: file => FileActionSheet.show({ file }),
+            onFileAction: file =>
+                FileActionSheet.show({ file, canUnshare: true, fileAutoOpen: true })
         }));
         return (
             <ChatItem

--- a/app/components/mocks/mock-action-sheet.js
+++ b/app/components/mocks/mock-action-sheet.js
@@ -47,7 +47,7 @@ export default class MockActionSheet extends Component {
             sizeFormatted: '22 MB',
             uploadedAt: new Date().getTime()
         };
-        FileActionSheet.show(file);
+        FileActionSheet.show({ file });
     }
 
     render() {


### PR DESCRIPTION
#### Relevant info and issue/PR links 

https://app.clubhouse.io/peerio/story/18323/mobile-unshare-inline-files

#### Testing instructions  

Files shared in a DM or channel should have an 'Unshare' option if the person is the owner of the file.

Possible regressions:

- each place with an action sheet for the file - files list, files view
- no file auto open on download
- no routing to file list after deleting file from files view

----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
